### PR TITLE
Correção do bug de Timezone errada

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,7 @@ import os
 
 from telegram import Update, Bot
 from telegram.ext import Dispatcher, CommandHandler
-from datetime import datetime, time
-
+from datetime import datetime, time, timedelta, timezone
 
 def mackenzie_callback(bot, update: Update, **optional_args):
     update.message.reply_text("O Mackenzie já voltou pro Intercomp?", quote=False)
@@ -34,8 +33,8 @@ def contagem_callback(bot, update, **optional_args):
         return days, hours, minutes, seconds
 
     data_intercomp = datetime.strptime('2020-06-11 00:00:01', '%Y-%m-%d %H:%M:%S')
-    now = datetime.now()
 
+    now = datetime.now().astimezone(timezone(timedelta(hours=-3))) #Ajustando timezone para o padrão brasileiro (UTC-3)
     update.message.reply_text("FALTAM %d dias, %d horas, %d minutos e %d segundos pro INTERCOMP NINJA EDITION"
                               % daysHoursMinutesSecondsFromSeconds(dateDiffInSeconds(now, data_intercomp)), quote=False)
 


### PR DESCRIPTION
Foi feita a alteração na linha 37, onde o timezone estava setado para UTC-0, sendo alterado para o padrão brasileiro (UTC-3)